### PR TITLE
fix login (python 2.7 specific?)

### DIFF
--- a/rootio/user/models.py
+++ b/rootio/user/models.py
@@ -69,7 +69,7 @@ class User(RootioUser, UserMixin):
     def check_password(self, password):
         if self.password is None:
             return False
-        return check_password_hash(self.password, password)
+        return check_password_hash(self.password.encode('latin-1'), password)
 
 
     @property


### PR DESCRIPTION
Without this change I get the following exception when I try to log in:

```
Error on request:                                                                            [39/1948]
Traceback (most recent call last):
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/werkzeug/serving.py", line 177, in run_wsgi
    execute(self.server.app)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/werkzeug/serving.py", line 165, in execute
    application_iter = app(environ, start_response)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/rootio/web/rootio/frontend/views.py", line 95, in login
    form.password.data)
  File "/opt/rootio/web/rootio/user/models.py", line 96, in authenticate
    authenticated = user.check_password(password)
  File "/opt/rootio/web/rootio/user/models.py", line 62, in check_password
    return check_password_hash(self.password, password)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/werkzeug/security.py", line 224, in check_password_hash
    return safe_str_cmp(_hash_internal(method, salt, password)[0], hashval)
  File "/opt/rootio/venvs/web/lib/python2.7/site-packages/werkzeug/security.py", line 117, in safe_str_cmp
    return _builtin_safe_str_cmp(a, b)
TypeError: 'unicode' does not have the buffer interface
```
